### PR TITLE
fix(help-texts): improve help for start and change commands

### DIFF
--- a/command/change.go
+++ b/command/change.go
@@ -27,9 +27,10 @@ type ChangeCommand struct {
 // Help should return long-form help text.
 func (c *ChangeCommand) Help() string {
 	helpText := `
-Usage: sloppy change [OPTIONS] (PROJECT/SERVICE/APP | [PROJECT] FILENAME)
+Usage: sloppy change [OPTIONS] (FILENAME | PROJECT/SERVICE/APP)
 
-  Sets the new values for the given app.
+  Update an entire project or an individual app.
+  If the project doesn't exist yet, it's created.
 
 Options:
 
@@ -43,8 +44,10 @@ Options:
 
 Examples:
 
-  sloppy change -m 128 letschat/frontend/apache
+  sloppy change sloppy.json
   sloppy change -var=domain:abc.sloppy.zone letschat.json
+  sloppy change -m 128 letschat/frontend/apache
+  sloppy change --instances 2 letschat/frontend/apache
 `
 	return strings.TrimSpace(helpText)
 }
@@ -243,5 +246,5 @@ func (c *ChangeCommand) updateProject(args []string) int {
 
 // Synopsis should return a one-line, short synopsis of the command.
 func (c *ChangeCommand) Synopsis() string {
-	return "Change the configuration of an application on the fly"
+	return "Change a project or app on the fly"
 }

--- a/command/start.go
+++ b/command/start.go
@@ -23,13 +23,14 @@ func (c *StartCommand) Help() string {
 	helpText := `
 Usage: sloppy start [OPTIONS] FILENAME
 
-  Start a new project on the sloppy service
+  Create a new project. Can also use 'sloppy change' for this.
 
 Options:
   -v, --var=[]     values to set for placeholders
 
 Examples:
 
+  sloppy start sloppy.json
   sloppy start --var=domain:mydomain.sloppy.zone --var=memory:128 myproject.json
 `
 	return strings.TrimSpace(helpText)
@@ -103,5 +104,5 @@ func (c *StartCommand) Run(args []string) int {
 
 // Synopsis should return a one-line, short synopsis of the command.
 func (c *StartCommand) Synopsis() string {
-	return "Start a new project on the sloppy service"
+	return "Create a new project"
 }

--- a/command/start_test.go
+++ b/command/start_test.go
@@ -18,7 +18,7 @@ func TestStartCommand_implements(t *testing.T) {
 		t.Errorf("Help = %s", c.Help())
 	}
 
-	if !strings.Contains(c.Synopsis(), "Start") {
+	if !strings.Contains(c.Synopsis(), "Create") {
 		t.Errorf("Synopsis = %s", c.Synopsis())
 	}
 }


### PR DESCRIPTION
Make it much more obvious that change can update an entire project, given a json or yml file.

Hint at change also being able to create a project, make for simpler deploy scripts (don't need to test if the project already exists).

Fixes #24

Doesn't improve the 'error: A project with the same name already exists. Did you mean to change it?', since that is passed through from apiserver. With the updated help it should be easy enough to understand though.