### PR TITLE
add make target for updating sloppose dependency

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,4 @@
+# extending golang to build and test locally and on CI
 FROM golang:1.9.3
 
 ENV JQ_VERSION 1.5
@@ -7,6 +8,8 @@ RUN apt-get -y -q update && \
     apt-get -y -q install httpie && \
     curl -fsSL "$JQ_DOWNLOAD_URL" -o jq && \
     chmod +x jq && mv jq /usr/local/bin/jq && \
+    # godep
+    go get github.com/tools/godep && \
     # Windows Resource generation
     go get github.com/josephspurrier/goversioninfo && \
     go install github.com/josephspurrier/goversioninfo/cmd/goversioninfo && \

--- a/Makefile
+++ b/Makefile
@@ -6,6 +6,8 @@ GIT_COMMIT=$(shell git rev-parse HEAD)
 # Default docker image
 DOCKER_IMAGE := sloppy/go-cross:latest
 
+SLOPPOSE=github.com/sloppyio/sloppose/pkg/converter
+
 # env vars passed through directly to Docker's build scripts
 DOCKER_ENVS := \
 	-e GIT_COMMIT=$(GIT_COMMIT)\
@@ -39,6 +41,9 @@ beta: bundle
 
 test: bundle
 	$(DOCKER_RUN_DOCKER) scripts/make.sh test
+
+update-sloppose:
+	$(DOCKER_RUN_DOCKER) go get -u $(SLOPPOSE) && godep update $(SLOPPOSE)
 
 test-local: bundle
 	scripts/make.sh test


### PR DESCRIPTION
Not sure yet why it won't work even after adding godep to our Docker image. Stills fails with
```
/bin/sh: godep: command not found
make: *** [update-sloppose] Error 127
```
Running it standalone works fine:
```
$ docker run -it sloppy/go-cross:latest godep
Godep is a tool for managing Go package dependencies.
```