### PR TITLE
remove broken httpie build dependency

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,9 +4,7 @@ FROM golang:1.9.3
 ENV JQ_VERSION 1.5
 ENV JQ_DOWNLOAD_URL https://github.com/stedolan/jq/releases/download/jq-$JQ_VERSION/jq-linux32
 
-RUN apt-get -y -q update && \
-    apt-get -y -q install httpie && \
-    curl -fsSL "$JQ_DOWNLOAD_URL" -o jq && \
+RUN curl -fsSL "$JQ_DOWNLOAD_URL" -o jq && \
     chmod +x jq && mv jq /usr/local/bin/jq
 
 # dep


### PR DESCRIPTION
can't install it anymore, but since its apparently not needed anywhere, drop it